### PR TITLE
Add some memory to login state

### DIFF
--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -9,17 +9,19 @@ class StaticVariables {
 
   static const String RESSOURCE_PATH = 'res/';
   static const String IMAGE_PATH = RESSOURCE_PATH + 'images/';
-  static const String FAVORITES_REGISTRATION_BUTTON = "Register Favorited Courses";
+  static const String FAVORITES_REGISTRATION_BUTTON = "Register These Courses";
 
   /* Settings Page */
+  static const String GUEST_NAME ='Guest';
   static const String LOGGED_IN_AS ='Logged in as';
   static const String LOGOUT_BUTTON ='Log out';
+  static const String LOGIN_BUTTON ='Log in';
   static const String STATUS ='Status';
   static const String DEPARTMENT ='Department';
   static const String CONTACT_OFFICE ='Contact International Office';
   static const String CIE_CERTIFICATE ='Courses in English Certificate';
   static const String IE_CERTIFICATE ='International Engineering Certificate';
-  static const String TAKEN_COURSES ='Taken Courses';
+  static const String TAKEN_COURSES ='Course History';
 
   /* Settings/Taken Courses Page */
   static const String TOTAL_OF = 'Total of';

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -3,7 +3,9 @@ import 'package:cie_team1/utils/cieColor.dart';
 import 'package:cie_team1/utils/cieStyle.dart';
 import 'package:cie_team1/utils/routes.dart';
 import 'package:cie_team1/utils/staticVariables.dart';
+import 'package:cie_team1/utils/fileStore.dart';
 import 'package:flutter/material.dart';
+import 'dart:io';
 
 class LoginForm extends StatefulWidget {
   const LoginForm({Key key}) : super(key: key);
@@ -30,7 +32,26 @@ class LoginFormState extends State<LoginForm> {
   final GlobalKey<FormFieldState<String>> _passwordFieldKey =
       new GlobalKey<FormFieldState<String>>();
 
-  void _handleSubmitted() async {
+  void _initLoginFile() {
+    FileStore.getFile(FileStore.LOGIN);
+    FileStore.readFileAsString(FileStore.LOGIN).then((String value) {
+      if (value == null) {
+        FileStore.getFile(FileStore.LOGIN).then((File file) {
+          file.writeAsString("false");
+        });
+      }
+    });
+  }
+
+  void _handleSubmitted(bool isUsingGuestMode) async {
+    FileStore.getFile(FileStore.LOGIN).then((File file) {
+      file.writeAsString((!isUsingGuestMode).toString());
+    });
+    setState(() {
+      _loggedIn = !isUsingGuestMode;
+      print(_loggedIn);
+    });
+
     //TODO remove the line below and use the comments to activate form validation
     Navigator.of(context).pushReplacementNamed(Routes.TabPages);
     //
@@ -70,95 +91,100 @@ class LoginFormState extends State<LoginForm> {
   }
 
   @override
-  Widget build(BuildContext context) => new Scaffold(
-        key: _scaffoldKey,
-        body: new Container(
-          child: new SafeArea(
-            top: false,
-            bottom: false,
-            child: new Form(
-              key: _formKey,
-              autovalidate: _autoValidate,
-              child: new ListView(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0, vertical: 25.0),
-                children: <Widget>[
-                  new Image.asset(StaticVariables.IMAGE_PATH + 'hm_logo.png'),
-                  new Padding(padding: const EdgeInsets.only(top: 35.0)),
-                  new Text(
-                    "Courses in English",
-                    style: CiEStyle.getAppBarTitleStyle(context),
-                    textAlign: TextAlign.center,
+  Widget build(BuildContext context) {
+    _initLoginFile();
+    return new Scaffold(
+      key: _scaffoldKey,
+      body: new Container(
+        child: new SafeArea(
+          top: false,
+          bottom: false,
+          child: new Form(
+            key: _formKey,
+            autovalidate: _autoValidate,
+            child: new ListView(
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0, vertical: 25.0),
+              children: <Widget>[
+                new Image.asset(StaticVariables.IMAGE_PATH + 'hm_logo.png'),
+                new Padding(padding: const EdgeInsets.only(top: 35.0)),
+                new Text(
+                  "Courses in English",
+                  style: CiEStyle.getAppBarTitleStyle(context),
+                  textAlign: TextAlign.center,
+                ),
+                new Padding(padding: const EdgeInsets.only(top: 25.0)),
+                new TextFormField(
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'E-Mail',
                   ),
-                  new Padding(padding: const EdgeInsets.only(top: 25.0)),
-                  new TextFormField(
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      labelText: 'E-Mail',
+                  keyboardType: TextInputType.emailAddress,
+                  onSaved: (String value) {
+                    loginData.email = value;
+                  },
+                  validator: _validateMail,
+                ),
+                new Padding(padding: const EdgeInsets.only(top: 25.0)),
+                new TextFormField(
+                  key: _passwordFieldKey,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'Password',
+                  ),
+                  obscureText: true,
+                  onSaved: (String value) {
+                    loginData.password = value;
+                  },
+                  validator: _validatePassword,
+                ),
+                new Container(
+                  padding:
+                  const EdgeInsets.fromLTRB(25.0, 25.0, 25.0, 25.0),
+                  child: new FlatButton(
+                    color: CiEStyle.getLogoutButtonColor(),
+                    shape: new RoundedRectangleBorder(
+                        borderRadius: CiEStyle.getButtonBorderRadius()),
+                    onPressed: ()=> _handleSubmitted(false),
+                    child: new Text(
+                      'LOGIN',
+                      style: new TextStyle(color: Colors.white),
                     ),
-                    keyboardType: TextInputType.emailAddress,
-                    onSaved: (String value) {
-                      loginData.email = value;
-                    },
-                    validator: _validateMail,
                   ),
-                  new Padding(padding: const EdgeInsets.only(top: 25.0)),
-                  new TextFormField(
-                    key: _passwordFieldKey,
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                      labelText: 'Password',
-                    ),
-                    obscureText: true,
-                    onSaved: (String value) {
-                      loginData.password = value;
-                    },
-                    validator: _validatePassword,
-                  ),
-                  new Container(
-                    padding:
-                        const EdgeInsets.fromLTRB(25.0, 25.0, 25.0, 25.0),
-                    child: new FlatButton(
-                      color: CiEStyle.getLogoutButtonColor(),
-                      shape: new RoundedRectangleBorder(borderRadius: CiEStyle.getButtonBorderRadius()),
-                      onPressed: _handleSubmitted,
-                      child: new Text(
-                        'LOGIN',
-                        style: new TextStyle(color: Colors.white),
-                      ),
-                    ),
-                  ),
+                ),
 
-                   new Text(
-                    "Don't have an Account?",
-                    style: new TextStyle(
-                        color: CiEColor.red),
-                    textAlign: TextAlign.center,
-                  ),
-                  new Container(
-                    padding: const EdgeInsets.fromLTRB(25.0, 10.0, 25.0, 10.0),
+                new Text(
+                  "Don't have an Account?",
+                  style: new TextStyle(
+                      color: CiEColor.red),
+                  textAlign: TextAlign.center,
+                ),
+                new Container(
+                  padding: const EdgeInsets.fromLTRB(25.0, 10.0, 25.0, 10.0),
                   child: new FlatButton(
                     color: CiEColor.red,
-                    shape: new RoundedRectangleBorder(borderRadius: CiEStyle.getButtonBorderRadius()),
-                    onPressed: _handleSubmitted,
+                    shape: new RoundedRectangleBorder(
+                        borderRadius: CiEStyle.getButtonBorderRadius()),
+                    onPressed: ()=> _handleSubmitted(true),
                     child: new Text(
                       'Login as Guest',
                       style: new TextStyle(
-                        color: Colors.white),
+                          color: Colors.white),
                     ),
                   ),
-                  ),
-                  new Text(
-                    "Forgot your password?",
-                    style: new TextStyle(
-                        color: CiEColor.red),
-                    textAlign: TextAlign.center,
-                  ),
-                  
-                ],
-              ),
+                ),
+                new Text(
+                  "Forgot your password?",
+                  style: new TextStyle(
+                      color: CiEColor.red),
+                  textAlign: TextAlign.center,
+                ),
+
+              ],
             ),
           ),
         ),
-      );
+      ),
+    );
+  }
 }

--- a/lib/views/maps.dart
+++ b/lib/views/maps.dart
@@ -97,7 +97,7 @@ class _MapPageState extends State<MapPage> {
                 children: <Widget>[
                   Text(campus, style: CiEStyle.getMapsTitleStyle(),),
                   SizedBox(height: 8.0),
-                  new Text('Click on the map to get directions.', style: CiEStyle.getMapsDescriptionStyle())
+                  new Text('Click on the map for directions.', style: CiEStyle.getMapsDescriptionStyle())
               ],
             )
             ),

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:cie_team1/presenter/currentUserPresenter.dart';
 import 'package:cie_team1/views/takenCourses.dart';
@@ -8,6 +9,7 @@ import 'package:cie_team1/utils/routes.dart';
 import 'package:cie_team1/utils/staticVariables.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:cie_team1/utils/fileStore.dart';
 
 class Settings extends StatefulWidget {
   Settings({Key key, this.title}) : super(key: key);
@@ -21,6 +23,13 @@ class _SettingsState extends State<Settings> {
   static CurrentUserPresenter currentUserPresenter = new CurrentUserPresenter();
   int credits = currentUserPresenter.getTotalCredits();
   int engCredits = currentUserPresenter.getDep3Credits();
+  bool _loggedIn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateLoggedInState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +67,7 @@ class _SettingsState extends State<Settings> {
                                 style: CiEStyle.getSettingsStyle(),
                               ),
                               new Text(
-                                " " + currentUserPresenter.getFullName(),
+                                " " + (_loggedIn ? currentUserPresenter.getFullName() : StaticVariables.GUEST_NAME),
                                 style: CiEStyle.getSettingsInfoStyle(),
                               ),
                             ],
@@ -69,7 +78,7 @@ class _SettingsState extends State<Settings> {
                             borderRadius: CiEStyle.getButtonBorderRadius()),
                         color: CiEColor.red,
                         child: new Text(
-                          StaticVariables.LOGOUT_BUTTON,
+                          _loggedIn ? StaticVariables.LOGOUT_BUTTON : StaticVariables.LOGIN_BUTTON,
                           style: CiEStyle.getSettingsLogoutStyle(),
                         ),
                       ),
@@ -195,7 +204,22 @@ class _SettingsState extends State<Settings> {
     }
   }
 
+  void _updateLoggedInState() {
+    FileStore.readFileAsString(FileStore.LOGIN).then((String value) {
+      setState(() {
+        _loggedIn = value == "true" ? true : false;
+      });
+    });
+  }
+
   void _logout(BuildContext context) {
+    // If logged in, log out. If user hasn't signed in, set to logged in
+    // Not necessary to change state since we are navigating to a different page
+    FileStore.readFileAsString(FileStore.LOGIN).then((String value) {
+      FileStore.getFile(FileStore.LOGIN).then((File file) {
+        file.writeAsString(value == "true" ? "false" : "true");
+      });
+    });
     //TODO maybe some more things are required here later
     Navigator.pushReplacementNamed(context, Routes.Login);
   }

--- a/test/utils/fileStore_test.dart
+++ b/test/utils/fileStore_test.dart
@@ -1,0 +1,16 @@
+import 'package:cie_team1/utils/fileStore.dart';
+import 'package:test/test.dart';
+
+@Timeout(const Duration(seconds: 10))
+
+void main() {
+  group("getFile", () {
+    test('1', () {
+      try {
+        FileStore.getFile(FileStore.LOGIN);
+      } catch(e) {
+        fail("Failed to retrieve file");
+      }
+    });
+  });
+}

--- a/test/views/settings_test.dart
+++ b/test/views/settings_test.dart
@@ -30,10 +30,10 @@ void main() {
             expect(widget.data, StaticVariables.LOGGED_IN_AS);
             counter++;
           } else if (counter == 1) {
-            expect(widget.data, " " + new CurrentUserPresenter().getFullName());
+            expect(widget.data, " " + StaticVariables.GUEST_NAME);
             counter++;
           } else if (counter == 2) {
-            expect(widget.data, StaticVariables.LOGOUT_BUTTON);
+            expect(widget.data, StaticVariables.LOGIN_BUTTON);
             counter++;
           } else if (counter == 3) {
             expect(widget.data, StaticVariables.STATUS + " : ");


### PR DESCRIPTION
- This commit **doesn't** worry about using actual login files (username, password)
- I didn't actually make that many changes to login.dart, the git diff just went crazy
- Just keeps track of whether the user logged in as guest or actually logged in
- Renders a Log in/Log out button on the Settings page accordingly
-This functionality can be extended in the future for a more personal settings page

<img width="288" alt="screen shot 2018-06-07 at 8 01 35 pm" src="https://user-images.githubusercontent.com/9795754/41117581-c1749b24-6a8d-11e8-8ca6-086737943df8.png">
<img width="280" alt="screen shot 2018-06-07 at 8 01 28 pm" src="https://user-images.githubusercontent.com/9795754/41117582-c1944546-6a8d-11e8-8372-5b567fc2f208.png">
