### PR TITLE
Fix blue page that appears to have survived the timetable merge

### DIFF
--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -53,7 +53,6 @@ class TabsPageState extends State<TabsPage> {
           // Behaves as Courses Page
           new MapPage(),
           new Schedule(),
-          new Container(color: Colors.blue),
           new CourseList(courseListPresenter, true),
           // Behaves as Favorites Page
           new Settings(),

--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -53,8 +53,8 @@ class TabsPageState extends State<TabsPage> {
           // Behaves as Courses Page
           new MapPage(),
           new Schedule(),
-          new CourseList(courseListPresenter, true),
           // Behaves as Favorites Page
+          new CourseList(courseListPresenter, true),
           new Settings(),
         ],
       ),


### PR DESCRIPTION
- Fixed one line from the monster merge. Looking good!
Before
<img width="268" alt="screen shot 2018-06-07 at 10 26 56 pm" src="https://user-images.githubusercontent.com/9795754/41124355-051eaefa-6aa2-11e8-94a7-8ec33d1faf60.png">
After
<img width="264" alt="screen shot 2018-06-07 at 10 26 38 pm" src="https://user-images.githubusercontent.com/9795754/41124357-05c67914-6aa2-11e8-9e2c-b358014e2941.png">
