### PR TITLE
Json user settings data

### DIFF
--- a/lib/di/currentUser_di.dart
+++ b/lib/di/currentUser_di.dart
@@ -1,8 +1,7 @@
 import 'package:cie_team1/model/user/currentUser.dart';
 import 'package:cie_team1/model/user/currentUser_mock.dart';
 import 'package:cie_team1/model/user/currentUser_prod.dart';
-
-enum Flavor { MOCK, PROD }
+import 'package:cie_team1/utils/staticVariables.dart';
 
 //DI
 class UserInjector {

--- a/lib/model/course/course.dart
+++ b/lib/model/course/course.dart
@@ -93,11 +93,26 @@ class CourseBuilder {
     return this;
   }
 
+  static String buildProfessorName(dynamic jsonData) {
+    dynamic professor = (jsonData['dates'][0]['lecturer'][0]);
+    String title = professor['title'].toString();
+    title = title != "null" ? title + " ": "";
+    String firstName = professor['firstName'].toString();
+    firstName = firstName != "null" ? firstName + " " : "";
+    String lastName = professor['lastName'].toString();
+    lastName = lastName != "null" ? lastName : "";
+    return title + firstName + lastName;
+  }
+
+  static String buildDescription(dynamic jsonData) {
+    return jsonData['description'] != null ? jsonData['description'] : "";
+  }
+
   factory CourseBuilder.fromJson(Map<String, dynamic> jsonData) {
     String dep = ((jsonData['correlations'][0]['organiser']));
     return new CourseBuilder(
       id: jsonData['id'],
-      description: jsonData['description'],
+      description: buildDescription(jsonData),
       isCoterie: jsonData['isCoterie'],
       hasHomeBias: jsonData['hasHomeBias'],
       correlations: jsonData['correlations'],
@@ -105,13 +120,14 @@ class CourseBuilder {
       name: jsonData['name'],
       shortName: jsonData['shortName'],
       actions: jsonData['actions'],
-      faculty: dep.substring(3, dep.length)
+      faculty: dep.substring(3, dep.length),
+      professorName: buildProfessorName(jsonData)
     );
   }
 
   CourseBuilder({this.id, this.description, this.isCoterie, this.hasHomeBias,
     this.correlations, this.dates, this.name, this.shortName, this.actions,
-    this.faculty});
+    this.faculty, this.professorName});
 
   Course build(){
     return new Course(

--- a/lib/model/course/course.dart
+++ b/lib/model/course/course.dart
@@ -1,6 +1,5 @@
 class CourseBuilder {
   /* FIELDS FROM NINE */
-  //TODO: Implement These & Merge, delete nineAPIConsumer.dart's NineCourse class
   String id;
   String description;
   bool isCoterie;

--- a/lib/model/user/currentUser_mock.dart
+++ b/lib/model/user/currentUser_mock.dart
@@ -26,8 +26,17 @@ class CurrentUserMock implements CurrentUser {
     currentCourses.add(courses[17]);
     currentCourses.add(courses[43]);
 
-    currentUser = new User(
-        1, "Jane1", "Jane", "Doe", "07", "Local", currentCourses, prevCourses);
+    currentUser = new UserBuilder()
+        .withID("id-123")
+        .withUsername("Guest")
+        .withFirstName("Guest")
+        .withLastName("User")
+        .withDepartment("N/A")
+        .withStatus("N/A")
+        .withIsMetricsEnabled(true)
+        .withCurrentCourses(currentCourses)
+        .withPrevCourses(prevCourses)
+        .build();
   }
 
   @override

--- a/lib/model/user/currentUser_prod.dart
+++ b/lib/model/user/currentUser_prod.dart
@@ -1,15 +1,59 @@
+import 'package:cie_team1/model/course/course.dart';
+import 'package:cie_team1/model/course/courses_mock.dart';
 import 'package:cie_team1/model/user/currentUser.dart';
 import 'package:cie_team1/model/user/user.dart';
+import 'package:cie_team1/utils/fileStore.dart';
+import 'dart:convert';
 
 class CurrentUserProd implements CurrentUser {
-  User testUser;
+  List<Course> prevCourses = [];
+  List<Course> currentCourses = [];
+  User currentUser;
 
-  CoursesProd() {
-    //Todo: In the next Sprints
+  CurrentUserProd() {
+    CoursesMock coursesMock = new CoursesMock();
+    List<Course> courses = coursesMock.getCourses();
+    prevCourses.add(courses[0]);
+    prevCourses.add(courses[1]);
+    prevCourses.add(courses[2]);
+    prevCourses.add(courses[3]);
+
+    currentCourses.add(courses[4]);
+    currentCourses.add(courses[5]);
+    currentCourses.add(courses[8]);
+    currentCourses.add(courses[9]);
+    currentCourses.add(courses[10]);
+    currentCourses.add(courses[11]);
+    currentCourses.add(courses[12]);
+    currentCourses.add(courses[17]);
+    currentCourses.add(courses[43]);
+
+    currentUser = new UserBuilder()
+        .withID("id-123")
+        .withUsername("Guest")
+        .withFirstName("Guest")
+        .withLastName("User")
+        .withDepartment("N/A")
+        .withStatus("N/A")
+        .withIsMetricsEnabled(true)
+        .withCurrentCourses(currentCourses)
+        .withPrevCourses(prevCourses)
+        .build();
+
+    FileStore.readFileAsString(FileStore.USER_SETTINGS).then((String val) {
+      if (val != null) {
+        Map<String, dynamic> map = json.decode(val);
+        User u = new UserBuilder.fromJson(map).build();
+        currentUser.isLoggedIn = u.isLoggedIn;
+        currentUser.firstName = u.firstName;
+        currentUser.lastName = u.lastName;
+        currentUser.department = u.department;
+      }
+    });
   }
 
   @override
   User getCurrentUser() {
-    return testUser;
+    return currentUser;
   }
 }

--- a/lib/model/user/user.dart
+++ b/lib/model/user/user.dart
@@ -1,15 +1,142 @@
 import 'package:cie_team1/model/course/course.dart';
 
-class User {
-  final int id;
-  final String username;
-  final String firstName;
-  final String lastName;
-  final String department;
-  final String status;
+class UserBuilder {
+  String language = "";
+  String name = "";
+  String department = "";
+  String degree = "";
+  bool isLoggedIn = false;
+  bool isMetricsEnabled = true;
+  String id = "";
+  String username = "";
+  String firstName = "";
+  String lastName = "";
+  String status = "";
   List<Course> currentCourses;
   List<Course> prevCourses;
 
-  User(this.id, this.username, this.firstName, this.lastName, this.department,
-      this.status, this.currentCourses, this.prevCourses);
+  // Standard Builder Pattern Implementation
+  UserBuilder withID(String id) {
+    this.id = id != null ? id: null;
+    return this;
+  }
+
+  UserBuilder withLanguage(String language) {
+    this.language = language != null ? language : null;
+    return this;
+  }
+
+  UserBuilder withName(String name) {
+    this.name = name != null ? name : null;
+    return this;
+  }
+
+  UserBuilder withDepartment(String department) {
+    this.department = department != null ? department : null;
+    return this;
+  }
+
+  UserBuilder withDegree(String degree) {
+    this.degree = degree != null ? degree : null;
+    return this;
+  }
+
+  UserBuilder withIsLoggedIn(bool isLoggedIn) {
+    this.isLoggedIn = isLoggedIn != null ? isLoggedIn : null;
+    return this;
+  }
+
+  UserBuilder withIsMetricsEnabled(bool isMetricsEnabled) {
+    this.isMetricsEnabled = isMetricsEnabled != null ? isMetricsEnabled : null;
+    return this;
+  }
+
+  UserBuilder withUsername(String username) {
+    this.username = username != null ? username: null;
+    return this;
+  }
+
+  UserBuilder withFirstName(String firstName) {
+    this.firstName = firstName != null ? firstName : null;
+    return this;
+  }
+
+  UserBuilder withLastName(String lastName) {
+    this.lastName = lastName != null ? lastName : null;
+    return this;
+  }
+
+  UserBuilder withStatus(String status) {
+    this.status = status != null ? status : null;
+    return this;
+  }
+
+  UserBuilder withCurrentCourses(List<Course> currentCourses) {
+    this.currentCourses = currentCourses != null ? currentCourses : null;
+    return this;
+  }
+
+  UserBuilder withPrevCourses(List<Course> prevCourses) {
+    this.prevCourses = prevCourses != null ? prevCourses : null;
+    return this;
+  }
+
+  factory UserBuilder.fromJson(Map<String, dynamic> jsonData) {
+    return new UserBuilder(
+      id: jsonData['id'],
+      language: jsonData['language'],
+      name: jsonData['name'],
+      firstName: jsonData['firstName'],
+      lastName: jsonData['lastName'],
+      department: jsonData['department'],
+      degree: jsonData['degree'],
+      isLoggedIn: jsonData['isLoggedIn'] == 'true' ? true : false,
+      isMetricsEnabled: jsonData['isMetricsEnabled'] == 'true' ? true: false
+    );
+  }
+
+  UserBuilder({this.id, this.language, this.name, this.firstName, this.lastName, this.department,
+      this.degree, this.isLoggedIn, this.isMetricsEnabled});
+
+  User build() {
+    return new User(this.id, this.language, this.name, this.department,
+        this.degree, this.isLoggedIn, this.isMetricsEnabled, this.username,
+        this.firstName, this.lastName, this.status, this.currentCourses,
+        this.prevCourses);
+  }
 }
+
+class User {
+  String id;
+  String language;
+  String name;
+  String department;
+  String degree;
+  bool isLoggedIn;
+  bool isMetricsEnabled;
+  String username;
+  String firstName;
+  String lastName;
+  String status;
+  List<Course> currentCourses;
+  List<Course> prevCourses;
+
+  User(this.id, this.language, this.name, this.department,
+      this.degree, this.isLoggedIn, this.isMetricsEnabled, this.username, this.firstName, this.lastName,
+      this.status, this.currentCourses, this.prevCourses);
+
+  static Map<String, dynamic> toJson(User user) {
+    Map<String, String> map = new Map<String, String>();
+    map.putIfAbsent('id', ()=> user.id.toString());
+    map.putIfAbsent('language', ()=> user.language);
+    map.putIfAbsent('name', ()=> user.name);
+    map.putIfAbsent('firstName', ()=> user.firstName);
+    map.putIfAbsent('lastName', ()=> user.lastName);
+    map.putIfAbsent('department', ()=> user.department);
+    map.putIfAbsent('degree', ()=> user.degree);
+    map.putIfAbsent('isLoggedIn', ()=> user.isLoggedIn.toString());
+    map.putIfAbsent('isMetricsEnabled', ()=> user.isMetricsEnabled.toString());
+    return map;
+  }
+}
+

--- a/lib/presenter/courseListPresenter.dart
+++ b/lib/presenter/courseListPresenter.dart
@@ -24,6 +24,7 @@ class CourseListPresenter {
   // TODO: -Check if course is already stored before adding here
   // TODO: -Make the loop contents more relevant and move it somewhere else
   void addCoursesFromMemory() {
+    this.onChanged(true);
     List<Course> courseList = _courses.getCourses();
     bool didUpdate = false;
     FileStore.readFileAsString(FileStore.COURSES).then((String val){
@@ -39,11 +40,9 @@ class CourseListPresenter {
                 new Lecture(Campus.KARLSTRASSE, Weekday.Mon, new DayTime(10, 00),
                     new DayTime(11, 30), "R0.009")
               ])
-              .withDescription("")
               .withHoursPerWeek(2)
               .withEcts(2)
               .withProfessorEmail("example@hm.edu")
-              .withProfessorName("Max Mustermann")
               .withAvailable(CourseAvailability.AVAILABLE)
               .withIsFavorite(false);
           Course c = courseBuilder.build();

--- a/lib/presenter/currentUserPresenter.dart
+++ b/lib/presenter/currentUserPresenter.dart
@@ -103,49 +103,12 @@ class CurrentUserPresenter {
           _currentUser.getCurrentUser().isLoggedIn = isLoggedIn;
           this.onChanged(true);
         }
-        String firstName = settings['firstName'];
-        String lastName = settings['lastName'];
-        String department = settings['department'];
-        /*
-        print(firstName);
-        print(lastName);
-        print(department);
-        */
-        /*
-        _currentUser.getCurrentUser().firstName = firstName;
-        _currentUser.getCurrentUser().lastName = lastName;
-        _currentUser.getCurrentUser().department = department;
-        */
-      } else {
-        loadUserSettingsAsFirstUse();
       }
     });
-  }
-
-  void loadUserSettingsAsFirstUse() {
-    /*
-    print("FIRST USE");
-    _currentUser.getCurrentUser().isMetricsEnabled = true;
-    FileStore.readFileAsString(FileStore.USER_SETTINGS).then((String val) {
-      if (val != null) {
-        dynamic settings = json.decode(val);
-        print(".\t\tFROM LOGIN" + settings.toString());
-        UserBuilder builder = UserBuilder.fromJson(settings);
-        User tempUserObj = builder
-            .withIsMetricsEnabled(true)
-            .build();
-      } else {
-        print("ERR 134");
-      }
-    });
-    this.onChanged(true);
-    */
   }
 
   void saveUserSettings() {
-    print("BAD");
     String data = json.encode(User.toJson(_currentUser.getCurrentUser()));
-    print ("SaveUserSettings - " + data);
     FileStore.writeToFile(FileStore.USER_SETTINGS, data);
   }
 }

--- a/lib/presenter/timeTablePresenter.dart
+++ b/lib/presenter/timeTablePresenter.dart
@@ -2,12 +2,13 @@ import 'package:cie_team1/di/currentUser_di.dart';
 import 'package:cie_team1/model/course/course.dart';
 import 'package:cie_team1/model/user/currentUser.dart';
 import 'package:cie_team1/model/user/user.dart';
+import 'package:cie_team1/utils/staticVariables.dart';
 
 class TimeTablePresenter {
   CurrentUser _currentUser;
 
-  TimeTablePresenter() {
-    UserInjector.configure(Flavor.MOCK);
+  TimeTablePresenter(Flavor flavor) {
+    UserInjector.configure(flavor);
     _currentUser = new UserInjector().currentUser;
   }
 

--- a/lib/utils/cieStyle.dart
+++ b/lib/utils/cieStyle.dart
@@ -77,6 +77,22 @@ class CiEStyle {
     );
   }
 
+  static TextStyle getSettingsEnabledStyle() {
+    return new TextStyle(
+      fontSize: 16.0,
+      fontWeight: FontWeight.w200,
+      color: CiEColor.black
+    );
+  }
+
+  static TextStyle getSettingsDisabledStyle() {
+    return new TextStyle(
+      fontSize: 16.0,
+      fontWeight: FontWeight.w200,
+      color: CiEColor.mediumGray
+    );
+  }
+
   static TextStyle getSettingsLogoutStyle() {
     return new TextStyle(color: Colors.white);
   }

--- a/lib/utils/fileStore.dart
+++ b/lib/utils/fileStore.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 class FileStore {
   static const String COURSES = "_courses";
   static const String LOGIN = "_login";
+  static const String USER_SETTINGS = "_user";
 
   static Future<File> getFile(String resource) async {
     String dir = (await getApplicationDocumentsDirectory()).path;
@@ -21,13 +22,6 @@ class FileStore {
     } on FileSystemException {
       return null;
     }
-  }
-
-  static String readFileAsStringSync(String resource) {
-    readFileAsString(resource).then((value) {
-      return value;
-    });
-    return null;
   }
 
   static Future<File> writeToFile(String resource, String data) async {

--- a/lib/utils/fileStore.dart
+++ b/lib/utils/fileStore.dart
@@ -10,7 +10,7 @@ class FileStore {
 
   static Future<File> getFile(String resource) async {
     String dir = (await getApplicationDocumentsDirectory()).path;
-    String filename = "$dir/" + resource + ".txt";
+    String filename = "$dir/" + resource + ".json";
     return new File(filename);
   }
 
@@ -26,7 +26,7 @@ class FileStore {
 
   static Future<File> writeToFile(String resource, String data) async {
     String dir = (await getApplicationDocumentsDirectory()).path;
-    String filename = "$dir/" + resource + ".txt";
+    String filename = "$dir/" + resource + ".json";
     File f = new File(filename);
     f.writeAsString(data);
     return f;

--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -38,6 +38,10 @@ class StaticVariables {
   static const String TAKEN_COURSES = 'Taken Courses';
   static const String PRIVACY_BUTTON = 'Our Privacy Policy';
 
+  static const String GUEST_FIRST_NAME = "Guest";
+  static const String GUEST_LAST_NAME = "User";
+  static const String GUEST_DEPARTMENT = "N/A";
+
   /* Settings/Taken Courses Page */
   static const String TOTAL_OF = 'Total of';
   static const String ECTS = 'ECTS';

--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -1,3 +1,4 @@
+enum Flavor { MOCK, PROD }
 class StaticVariables {
   static const internationalOfficeEmail = 'mailto:international-office@hm.edu';
 
@@ -27,7 +28,8 @@ class StaticVariables {
 
   /* Settings Page */
   static const String LOGGED_IN_AS = 'Logged in as';
-  static const String LOGOUT_BUTTON = 'Log out';
+  static const String LOGOUT_BUTTON = 'Log Out';
+  static const String LOGIN_BUTTON = 'Log In';
   static const String STATUS = 'Status';
   static const String DEPARTMENT = 'Department';
   static const String CONTACT_OFFICE = 'Contact International Office';
@@ -44,4 +46,8 @@ class StaticVariables {
   static const String ALERT_YES = "COMPLETE";
   static const String ALERT_NO = "CANCEL";
   static const String ALERT_REGISTRATION_SUBMISSION = "Complete Registration?";
+
+  /* Metrics Strings */
+  static const String METRICS_ENABLED = "User Statistics Enabled";
+  static const String METRICS_DISABLED = "User Statistics Disabled";
 }

--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -48,6 +48,6 @@ class StaticVariables {
   static const String ALERT_REGISTRATION_SUBMISSION = "Complete Registration?";
 
   /* Metrics Strings */
-  static const String METRICS_ENABLED = "User Statistics Enabled";
-  static const String METRICS_DISABLED = "User Statistics Disabled";
+  static const String METRICS_ENABLED = "User Metrics Enabled";
+  static const String METRICS_DISABLED = "User Metrics Disabled";
 }

--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -66,6 +66,6 @@ class StaticVariables {
   static const String CONTACT = "Contact";
   static const String COURSE_DETAILS = "Course Details";
   static const String NO_DESCRIPTION =
-      "Sorry but there is currently no description available for this course.";
+      "Sorry, there no description available for this course. Please check again later";
   static const String PROFESSOR = "Professor";
 }

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -60,15 +60,6 @@ class LoginFormState extends State<LoginForm> {
             final String lastName =
                 json.decode(response.body)['user']['lastName'];
             var curriculum = json.decode(response.body)['curriculum']['organiser']['name'];
-            /*
-            print("Response status: ${response.statusCode}");
-            print("Response body: ${response.body}");
-            print("Response user: ${json.decode(response.body)['user']}");
-            print("Response id: $id");
-            print("Response firstName: $firstName");
-            print("Response lastName: $lastName");
-            print("Response curriculum: $curriculum");
-            */
             updateUserSettings(context, firstName, lastName, curriculum);
           }
         });
@@ -84,7 +75,7 @@ class LoginFormState extends State<LoginForm> {
   }
 
   void _handleGuestLogin() {
-    continueAsGuest(context);
+    updateUserSettings(context, null, null, null);
   }
 
   String _validateMail(String value) {
@@ -219,60 +210,33 @@ class LoginFormState extends State<LoginForm> {
     super.dispose();
   }
 
-  void updateUserSettings(BuildContext context, String firstName, String lastName, dynamic curriculum) {
+  void updateUserSettings(BuildContext context, String firstName,
+      String lastName, dynamic curriculum) {
+    bool isLoggedIn = false;
+    UserBuilder builder;
+    if (firstName != null && lastName != null && curriculum != null) {
+      isLoggedIn = true;
+
+    } else { // Continuing As Guest
+      firstName = "Guest";
+      lastName = "User";
+      curriculum = "N/A";
+    }
+
     FileStore.readFileAsString(FileStore.USER_SETTINGS).then((String val) {
       if (val != null) {
         dynamic settings = json.decode(val);
-        UserBuilder builder = UserBuilder.fromJson(settings);
-        User tempUserObj = builder
-          .withIsLoggedIn(true)
-          .withFirstName(firstName)
-          .withLastName(lastName)
-          .withDepartment(curriculum)
-          .build();
-        String data = json.encode(User.toJson(tempUserObj));
-        FileStore.writeToFile(FileStore.USER_SETTINGS, data);
-      } else {
-        UserBuilder builder = new UserBuilder();
-        User tempUserObj = builder
-            .withIsLoggedIn(true)
-            .withFirstName(firstName)
-            .withLastName(lastName)
-            .withDepartment(curriculum)
-            .build();
-        String data = json.encode(User.toJson(tempUserObj));
-        FileStore.writeToFile(FileStore.USER_SETTINGS, data);
+        builder = UserBuilder.fromJson(settings);
       }
-      Navigator.of(context).pushReplacementNamed(Routes.TabPages);
+      User tempUserObj = builder
+        .withFirstName(firstName)
+        .withLastName(lastName)
+        .withDepartment(curriculum)
+        .withIsLoggedIn(isLoggedIn)
+        .build();
+      String data = json.encode(User.toJson(tempUserObj));
+      FileStore.writeToFile(FileStore.USER_SETTINGS, data);
     });
-  }
-
-  void continueAsGuest(BuildContext context) {
-    FileStore.readFileAsString(FileStore.USER_SETTINGS).then((String val) {
-      if (val != null) {
-        dynamic settings = json.decode(val);
-        UserBuilder builder = UserBuilder.fromJson(settings);
-        User tempUserObj = builder
-            .withFirstName("Guest")
-            .withLastName("User")
-            .withDepartment("N/A")
-          .withIsLoggedIn(false)
-          .build();
-        String data = json.encode(User.toJson(tempUserObj));
-        FileStore.writeToFile(FileStore.USER_SETTINGS, data);
-      } else {
-        UserBuilder builder = new UserBuilder();
-        User tempUserObj = builder
-            .withFirstName("Guest")
-            .withLastName("User")
-            .withDepartment("N/A")
-          .withIsLoggedIn(false)
-          .build();
-        String data = json.encode(User.toJson(tempUserObj));
-        FileStore.writeToFile(FileStore.USER_SETTINGS, data);
-      }
-      Navigator.of(context).pushReplacementNamed(Routes.TabPages);
-    });
-
+    Navigator.of(context).pushReplacementNamed(Routes.TabPages);
   }
 }

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -237,8 +237,9 @@ class LoginFormState extends State<LoginForm> {
         .withIsLoggedIn(isLoggedIn)
         .build();
       String data = json.encode(User.toJson(tempUserObj));
-      FileStore.writeToFile(FileStore.USER_SETTINGS, data);
+      FileStore.writeToFile(FileStore.USER_SETTINGS, data).then((f) {
+        Navigator.of(context).pushReplacementNamed(Routes.TabPages);
+      });
     });
-    Navigator.of(context).pushReplacementNamed(Routes.TabPages);
   }
 }

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -218,15 +218,17 @@ class LoginFormState extends State<LoginForm> {
       isLoggedIn = true;
 
     } else { // Continuing As Guest
-      firstName = "Guest";
-      lastName = "User";
-      curriculum = "N/A";
+      firstName = StaticVariables.GUEST_FIRST_NAME;
+      lastName = StaticVariables.GUEST_LAST_NAME;
+      curriculum = StaticVariables.GUEST_DEPARTMENT;
     }
 
     FileStore.readFileAsString(FileStore.USER_SETTINGS).then((String val) {
       if (val != null) {
         dynamic settings = json.decode(val);
         builder = UserBuilder.fromJson(settings);
+      } else {
+        builder = new UserBuilder();
       }
       User tempUserObj = builder
         .withFirstName(firstName)

--- a/lib/views/schedule.dart
+++ b/lib/views/schedule.dart
@@ -8,7 +8,7 @@ import 'package:cie_team1/widgets/timeTableItem.dart';
 import 'package:flutter/material.dart';
 
 class Schedule extends StatelessWidget {
-  TimeTablePresenter timeTablePresenter = new TimeTablePresenter();
+  TimeTablePresenter timeTablePresenter = new TimeTablePresenter(Flavor.PROD);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -90,9 +90,14 @@ class _SettingsState extends State<Settings> {
                           shape: new RoundedRectangleBorder(
                               borderRadius: CiEStyle.getButtonBorderRadius()),
                           color: CiEColor.red,
-                          child: new Text(
+                          child: isLoggedIn == true ?
+                          new Text(
                             StaticVariables.LOGOUT_BUTTON,
-                            style: CiEStyle.getSettingsLogoutStyle(),
+                            style: CiEStyle.getSettingsLogoutStyle()
+                          ):
+                          new Text(
+                            StaticVariables.LOGIN_BUTTON,
+                            style: CiEStyle.getSettingsLogoutStyle()
                           ),
                         ),
                         new Padding(

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -130,30 +130,9 @@ class _SettingsState extends State<Settings> {
                               )
                             ],
                           )),
-                      new RaisedButton(
-                        onPressed: () => _logout(context),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: CiEStyle.getButtonBorderRadius()),
-                        color: CiEColor.red,
-                        child: new Text(
-                          isLoggedIn == true ? StaticVariables.LOGOUT_BUTTON:
-                            StaticVariables.LOGIN_BUTTON,
-                          style: CiEStyle.getSettingsLogoutStyle(),
-                        ),
-                      ),
                       new Padding(
                         padding : const EdgeInsets.only(top:5.0),
                       ),
-                      new RaisedButton(
-                        onPressed: () => _togglePrivacyPage(context),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: CiEStyle.getButtonBorderRadius()),
-                        color: CiEColor.red,
-                        child: new Text(
-                          StaticVariables.PRIVACY_BUTTON,
-                          style: CiEStyle.getSettingsPrivacyStyle(),
-                          ),
-                        ),
                         new Row(
                           children: <Widget>[
                             new Text(

--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -34,6 +34,7 @@ class TabsPageState extends State<TabsPage> {
     currentUserPresenter = new CurrentUserPresenter(_maybeChangeCallback,
         Flavor.PROD);
     courseListPresenter.addCoursesFromMemory();
+    currentUserPresenter.loadUserSettingsFromMemory();
     this._appTitle = TabItems[_tab].title;
   }
 

--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -34,8 +34,6 @@ class TabsPageState extends State<TabsPage> {
     currentUserPresenter = new CurrentUserPresenter(_maybeChangeCallback,
         Flavor.PROD);
     courseListPresenter.addCoursesFromMemory();
-    currentUserPresenter.loadUserSettingsAsFirstUse();
-    //currentUserPresenter.loadUserSettingsFromMemory();
     this._appTitle = TabItems[_tab].title;
   }
 

--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -1,4 +1,5 @@
 import 'package:cie_team1/presenter/courseListPresenter.dart';
+import 'package:cie_team1/presenter/currentUserPresenter.dart';
 import 'package:cie_team1/utils/cieColor.dart';
 import 'package:cie_team1/utils/cieStyle.dart';
 import 'package:cie_team1/views/maps.dart';
@@ -8,6 +9,7 @@ import 'package:cie_team1/widgets/courseList.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:cie_team1/utils/nineAPIConsumer.dart';
+import 'package:cie_team1/utils/staticVariables.dart';
 
 class TabsPage extends StatefulWidget {
   @override
@@ -17,6 +19,7 @@ class TabsPage extends StatefulWidget {
 class TabsPageState extends State<TabsPage> {
   PageController _tabController;
   CourseListPresenter courseListPresenter;
+  CurrentUserPresenter currentUserPresenter;
   var _appTitle = '';
 
   int _tab = 2; //change this to the default tab page value
@@ -28,8 +31,11 @@ class TabsPageState extends State<TabsPage> {
     NineAPIEngine.pullCourseJSON(context, true);
     _tabController = new PageController(initialPage: _tab);
     courseListPresenter = new CourseListPresenter(_maybeChangeCallback);
-    // TODO: Standard file protections, check if file exists, contents!=null etc.
+    currentUserPresenter = new CurrentUserPresenter(_maybeChangeCallback,
+        Flavor.PROD);
     courseListPresenter.addCoursesFromMemory();
+    currentUserPresenter.loadUserSettingsAsFirstUse();
+    //currentUserPresenter.loadUserSettingsFromMemory();
     this._appTitle = TabItems[_tab].title;
   }
 
@@ -52,6 +58,7 @@ class TabsPageState extends State<TabsPage> {
         title: new Text(
           _appTitle,
           style: CiEStyle.getAppBarTitleStyle(context),
+          textAlign: TextAlign.center,
         ),
         elevation: CiEStyle.getAppBarElevation(context),
         backgroundColor: CiEColor.lightGray,
@@ -66,7 +73,7 @@ class TabsPageState extends State<TabsPage> {
           new Schedule(),
           // Behaves as Favorites Page
           new CourseList(courseListPresenter, true),
-          new Settings(),
+          new Settings(currentUserPresenter),
         ],
       ),
       bottomNavigationBar: new BottomNavigationBar(

--- a/lib/views/takenCourses.dart
+++ b/lib/views/takenCourses.dart
@@ -14,8 +14,9 @@ class TakenCourses extends StatefulWidget {
 }
 
 class _TakenCoursesState extends State<TakenCourses> {
-  static CurrentUserPresenter currentUserPresenter = new CurrentUserPresenter();
+  static CurrentUserPresenter currentUserPresenter = new CurrentUserPresenter(_voidCallback, Flavor.PROD);
   int credits = currentUserPresenter.getTotalCredits();
+
 
   @override
   Widget build(BuildContext context) {
@@ -52,4 +53,5 @@ class _TakenCoursesState extends State<TakenCourses> {
           ),
         ));
   }
+  static void _voidCallback(bool didChange) {}
 }

--- a/lib/widgets/courseDetails.dart
+++ b/lib/widgets/courseDetails.dart
@@ -92,7 +92,6 @@ class _CourseDetailsState extends State<CourseDetails> {
         ),
       );
     }
-
     return new SingleChildScrollView(
       child: new Text(presenter.getDescription(id) + "\n\n" + StaticVariables.PROFESSOR + ": " + presenter.getProfessorName(id),
         style: CiEStyle.getCourseDetailsDescription(),
@@ -108,7 +107,6 @@ class _CourseDetailsState extends State<CourseDetails> {
           ),
       );
     }
-
     return new Expanded(
       child: new SingleChildScrollView(
         child: Text(presenter.getDescription(id) + "\n\n" + StaticVariables.PROFESSOR + ": " + presenter.getProfessorName(id),

--- a/lib/widgets/courseList.dart
+++ b/lib/widgets/courseList.dart
@@ -162,8 +162,9 @@ class CourseListState extends State<CourseList> {
     );
   }
 
-  Future<Null> handleRefreshIndicator(BuildContext context, CourseListPresenter presenter) {
+  handleRefreshIndicator(BuildContext context, CourseListPresenter presenter) {
     Future<Null> complete = NineAPIEngine.pullCourseJSON(context, true);
+    presenter.addCoursesFromMemory();
     presenter.onChanged(true);
     return complete;
   }

--- a/lib/widgets/courseList.dart
+++ b/lib/widgets/courseList.dart
@@ -8,6 +8,7 @@ import 'package:cie_team1/utils/staticVariables.dart';
 import 'package:cie_team1/widgets/courseListItem.dart';
 import 'package:flutter/material.dart';
 import 'package:cie_team1/utils/nineAPIConsumer.dart';
+import 'dart:async';
 
 class CourseList extends StatefulWidget {
   // Stateful because then this class can be used for favourites as well.
@@ -156,9 +157,15 @@ class CourseListState extends State<CourseList> {
 
     return new RefreshIndicator(
         child: new ListView(children: widgets),
-        onRefresh: ()=> NineAPIEngine.pullCourseJSON(context, true),
+        onRefresh: ()=> handleRefreshIndicator(context, courseListPresenter),
         color: Colors.blue,
     );
+  }
+
+  Future<Null> handleRefreshIndicator(BuildContext context, CourseListPresenter presenter) {
+    Future<Null> complete = NineAPIEngine.pullCourseJSON(context, true);
+    presenter.onChanged(true);
+    return complete;
   }
 
   Widget favoriteIcon(int id) {

--- a/test/model/user/user_test.dart
+++ b/test/model/user/user_test.dart
@@ -29,12 +29,20 @@ void main() {
         .build()
       ];
 
-      sut = new User(
-          42, 'Max42', 'Max', 'Mustermann', '7', 'sleeping', courses, courses);
+      sut = new UserBuilder()
+      .withID("id-123")
+      .withUsername("Max42")
+      .withFirstName("Max")
+      .withLastName("Mustermann")
+      .withDepartment("07")
+      .withStatus("sleeping")
+      .withCurrentCourses(courses)
+      .withPrevCourses(courses)
+      .build();
     });
 
     test('1', () {
-      expect(sut.id, 42);
+      expect(sut.id, "id-123");
     });
 
     test('2', () {
@@ -42,7 +50,7 @@ void main() {
     });
 
     test('2', () {
-      expect(sut.department, '7');
+      expect(sut.department, '07');
     });
 
     test('3', () {
@@ -93,7 +101,7 @@ void main() {
     test('1', () {
       final CurrentUserProd sut = new CurrentUserProd();
 
-      expect(sut.getCurrentUser(), null);
+      expect(sut.getCurrentUser()!=null, true);
     });
   });
 }

--- a/test/presenter/currentUserPresenter_test.dart
+++ b/test/presenter/currentUserPresenter_test.dart
@@ -1,13 +1,15 @@
 import 'package:cie_team1/di/currentUser_di.dart';
 import 'package:cie_team1/model/course/courses_mock.dart';
 import 'package:cie_team1/presenter/currentUserPresenter.dart';
+import 'package:cie_team1/utils/staticVariables.dart';
 import 'package:test/test.dart';
 
 void main() {
   CurrentUserPresenter sut;
 
   setUp(() {
-    sut = new CurrentUserPresenter();
+    void _voidCallback(bool didChange) {}
+    sut = new CurrentUserPresenter(_voidCallback, Flavor.MOCK);
   });
 
   group("User", () {

--- a/test/views/settings_test.dart
+++ b/test/views/settings_test.dart
@@ -35,7 +35,7 @@ void main() {
                 Flavor.MOCK).getFullName());
             counter++;
           } else if (counter == 2) {
-            expect(widget.data, StaticVariables.LOGIN_BUTTON);
+            expect(widget.data, StaticVariables.LOGOUT_BUTTON);
             counter++;
           } else if (counter == 3) {
             expect(widget.data, StaticVariables.PRIVACY_BUTTON);

--- a/test/views/settings_test.dart
+++ b/test/views/settings_test.dart
@@ -8,13 +8,15 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('settingspagewidget', () {
     testWidgets('1 widgetTest for settings', (WidgetTester tester) async {
+      _voidCallback(bool didChange) {print("wot");}
+      CurrentUserPresenter currentUserPresenter = new CurrentUserPresenter(_voidCallback, Flavor.MOCK);
 // Tells the tester to build a UI based on the widget tree passed to it
       await tester.pumpWidget(
         new StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return new MaterialApp(
               home: new Material(
-                child: new Center(child: new Settings()),
+                child: new Center(child: new Settings(currentUserPresenter)),
               ),
             );
           },
@@ -22,7 +24,6 @@ void main() {
       );
 
       final Iterable<Widget> listOfWidgets = tester.allWidgets;
-
       int counter = 0;
       for (Widget widget in listOfWidgets) {
         if (widget is Text) {
@@ -30,10 +31,11 @@ void main() {
             expect(widget.data, StaticVariables.LOGGED_IN_AS);
             counter++;
           } else if (counter == 1) {
-            expect(widget.data, " " + new CurrentUserPresenter().getFullName());
+            expect(widget.data, " " + new CurrentUserPresenter(_voidCallback,
+                Flavor.MOCK).getFullName());
             counter++;
           } else if (counter == 2) {
-            expect(widget.data, StaticVariables.LOGOUT_BUTTON);
+            expect(widget.data, StaticVariables.LOGIN_BUTTON);
             counter++;
           } else if (counter == 3) {
             expect(widget.data, StaticVariables.PRIVACY_BUTTON);
@@ -42,15 +44,15 @@ void main() {
             expect(widget.data, StaticVariables.STATUS + " : ");
             counter++;
           } else if (counter == 5) {
-            expect(widget.data,
-                " " + new CurrentUserPresenter().getCurrentUserStatus());
+            expect(widget.data, " " + new CurrentUserPresenter(_voidCallback,
+                Flavor.MOCK).getCurrentUserStatus());
             counter++;
           } else if (counter == 6) {
             expect(widget.data, StaticVariables.DEPARTMENT + " : ");
             counter++;
           } else if (counter == 7) {
-            expect(widget.data,
-                " " + new CurrentUserPresenter().getCurrentUserFaculty());
+            expect(widget.data, " " + new CurrentUserPresenter(_voidCallback,
+                Flavor.MOCK).getCurrentUserFaculty());
             counter++;
           } else if (counter == 8) {
             expect(widget.data, StaticVariables.CONTACT_OFFICE);

--- a/test/views/settings_test.dart
+++ b/test/views/settings_test.dart
@@ -35,7 +35,7 @@ void main() {
                 Flavor.MOCK).getFullName());
             counter++;
           } else if (counter == 2) {
-            expect(widget.data, StaticVariables.LOGOUT_BUTTON);
+            expect(widget.data, StaticVariables.LOGIN_BUTTON);
             counter++;
           } else if (counter == 3) {
             expect(widget.data, StaticVariables.PRIVACY_BUTTON);


### PR DESCRIPTION
- Can't yet merge depending on master -- the code on master looks fine on paper but doesn't like to compile with my ios simulator

- The code isn't that complicated but for various reasons it was more annoying to implement than it looks 🤒 

- Relevant for issues https://github.com/mobileappdevhm/dev-team-1-cie-app-in-flutter/issues/127 and https://github.com/mobileappdevhm/dev-team-1-cie-app-in-flutter/issues/93

- Not much changed in terms of front end, but this commit contains pretty much all user settings related data code we'll need.
- Contains a temporary UI slider for enabling/disabling metrics. This can be changed later, the main point is that it stores this setting locally using the new settings builder.
<img width="281" alt="screen shot 2018-06-17 at 9 32 34 pm" src="https://user-images.githubusercontent.com/9795754/41511398-3fa228a0-7276-11e8-8808-5f4f6c0af6e6.png">

- Also stores some information from logging into your Nine account. The settings page can differentiate between logging in from nine vs. guest mode.
<img width="279" alt="screen shot 2018-06-17 at 9 32 48 pm" src="https://user-images.githubusercontent.com/9795754/41511407-58d02f66-7276-11e8-8b24-a050137c5119.png">

- The skeleton for other settings (both of probable implementation and somewhat likely chances for implementation). These were implemented for easy integration later.

- Tests were refactored to accommodate for these changes. No tests were written yet, but some will be written in the future.
