### PR TITLE
Fix crash from changing tabs when focused on a text input field

### DIFF
--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -66,12 +66,14 @@ class TabsPageState extends State<TabsPage> {
         controller: _tabController,
         onPageChanged: _onPageChanged,
         children: <Widget>[
-          new CourseList(courseListPresenter, false, currentUserPresenter),
+          new CourseList(courseListPresenter, false,
+              currentUserPresenter, new FocusNode()),
           // Behaves as Courses Page
           new MapPage(),
           new Schedule(courseListPresenter),
           // Behaves as Favorites Page
-          new CourseList(courseListPresenter, true, currentUserPresenter),
+          new CourseList(courseListPresenter, true,
+              currentUserPresenter, new FocusNode()),
           new Settings(currentUserPresenter),
         ],
       ),
@@ -96,6 +98,7 @@ class TabsPageState extends State<TabsPage> {
   }
 
   void _onPageChanged(int tab) {
+    FocusScope.of(context).requestFocus(new FocusNode());
     setState(() {
       this._tab = tab;
     });

--- a/lib/widgets/courseList.dart
+++ b/lib/widgets/courseList.dart
@@ -16,14 +16,15 @@ class CourseList extends StatefulWidget {
   final CourseListPresenter courseListPresenter;
   final CurrentUserPresenter userPresenter;
   bool shouldFilterByFavorites = false;
+  FocusNode focus;
 
   CourseList(this.courseListPresenter, this.shouldFilterByFavorites,
-      this.userPresenter);
+      this.userPresenter, this.focus);
 
   @override
   State<StatefulWidget> createState() {
     return new CourseListState(
-        courseListPresenter, shouldFilterByFavorites, userPresenter);
+        courseListPresenter, shouldFilterByFavorites, userPresenter, focus);
   }
 
   void toggleFilter() {
@@ -40,9 +41,10 @@ class CourseListState extends State<CourseList> {
   String filter = "09";
   String searchValue = "";
   bool coursesRegistered = false;
+  FocusNode focus;
 
   CourseListState(this.courseListPresenter, this.shouldFilterByFavorites,
-      this.userPresenter);
+      this.userPresenter, this.focus);
 
   handleUpdate() async {
     //pullCourseJSON also checks for internet connectivity. This method should
@@ -111,6 +113,7 @@ class CourseListState extends State<CourseList> {
           padding: const EdgeInsets.fromLTRB(10.0, 1.0, 10.0, 1.0),
           alignment: Alignment.center,
           child: new TextField(
+            focusNode: focus,
             controller: c1,
             decoration: const InputDecoration(
               hintText: "Search by Course Name",

--- a/test/widgets/courseList_test.dart
+++ b/test/widgets/courseList_test.dart
@@ -93,7 +93,7 @@ void main() {
                 child: new Center(
                     child: new CourseList(
                         new CourseListPresenter(null), isFavoritesPage, new CurrentUserPresenter(null,
-                        Flavor.MOCK))),
+                        Flavor.MOCK), new FocusNode())),
               ),
             );
           },


### PR DESCRIPTION
https://github.com/mobileappdevhm/dev-team-1-cie-app-in-flutter/issues/91

The issue is half our fault and half the fault of the flutter API. The issue can be fixed without touching courseList.dart at all, but my previous fix (not committed) involved not using the PageController in tabs.dart.

It worked, but it was a little invasive and it's faster to just use flutter's Pagecontroller so I think this bandaid to unfocus (text) nodes when changing tabs is better.

Edit: just to be clear, this commit resolves the issue.