### PR TITLE
only adding the configuration file for firebase

### DIFF
--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AD_UNIT_ID_FOR_BANNER_TEST</key>
+	<string>ca-app-pub-3940256099942544/2934735716</string>
+	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
+	<string>ca-app-pub-3940256099942544/4411468910</string>
+	<key>CLIENT_ID</key>
+	<string>295085022628-n4ojtbpc18vkag96bpe66tnu5mjcck21.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.295085022628-n4ojtbpc18vkag96bpe66tnu5mjcck21</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDrw2N0HF4pByii1smwTlXALJ_jOL1bQCk</string>
+	<key>GCM_SENDER_ID</key>
+	<string>295085022628</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>mobileappdev.hm.edu.cieTeam1</string>
+	<key>PROJECT_ID</key>
+	<string>cieapp-1a92b</string>
+	<key>STORAGE_BUCKET</key>
+	<string>cieapp-1a92b.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<true></true>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false></false>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:295085022628:ios:c90fe375c161fb8c</string>
+	<key>DATABASE_URL</key>
+	<string>https://cieapp-1a92b.firebaseio.com</string>
+</dict>
+</plist>


### PR DESCRIPTION
Testing with a separate pull request because travis appears to have trouble building https://travis-ci.org/mobileappdevhm/dev-team-1-cie-app-in-flutter/builds/395369177?utm_source=github_status&utm_medium=notification (The command "flutter -v build ios --no-codesign" exited with 1.)

This commit only contains the configuration file for firebase ios. Would still need to be manually configured in Xcode.
1) open ios/Runner.xcworkspace/
2) In xcode, "File"->"Add files to Runner"
3) add the "GoogleService-Info.plist" file included in this commit
