### PR TITLE
Feature: use html view on course details page

### DIFF
--- a/lib/utils/cieStyle.dart
+++ b/lib/utils/cieStyle.dart
@@ -80,18 +80,14 @@ class CiEStyle {
 
   static TextStyle getSettingsEnabledStyle() {
     return new TextStyle(
-      fontSize: 16.0,
-      fontWeight: FontWeight.w200,
-      color: CiEColor.black
-    );
+        fontSize: 16.0, fontWeight: FontWeight.w200, color: CiEColor.black);
   }
 
   static TextStyle getSettingsDisabledStyle() {
     return new TextStyle(
-      fontSize: 16.0,
-      fontWeight: FontWeight.w200,
-      color: CiEColor.mediumGray
-    );
+        fontSize: 16.0,
+        fontWeight: FontWeight.w200,
+        color: CiEColor.mediumGray);
   }
 
   static TextStyle getSettingsLogoutStyle() {
@@ -170,7 +166,9 @@ class CiEStyle {
 
   static TextStyle getCourseListRefreshText() {
     return new TextStyle(
-        color: CiEColor.mediumGray, fontSize: 17.0, fontWeight: FontWeight.w300);
+        color: CiEColor.mediumGray,
+        fontSize: 17.0,
+        fontWeight: FontWeight.w300);
   }
 
   static TextStyle getCourseDetailsFooterTextStyle() {
@@ -190,21 +188,11 @@ class CiEStyle {
 
   static TextStyle getCourseDetailsHeadingStyle() {
     return new TextStyle(
-        fontSize: 20.0,
-        color: CiEColor.gray,
-        letterSpacing: 2.0
-    );
+        fontSize: 20.0, color: CiEColor.gray, letterSpacing: 2.0);
   }
 
   static double getCourseDetailsFontSize() {
     return 18.0;
-  }
-
-  static TextStyle getCourseDetailsDescription() {
-    return new TextStyle(
-      fontSize: 15.0,
-      color: CiEColor.gray,
-    );
   }
 
   static TextStyle getCourseDetailsConflictWarningText() {

--- a/lib/utils/staticVariables.dart
+++ b/lib/utils/staticVariables.dart
@@ -1,4 +1,5 @@
 enum Flavor { MOCK, PROD }
+
 class StaticVariables {
   static const internationalOfficeEmail = 'mailto:international-office@hm.edu';
 
@@ -58,7 +59,8 @@ class StaticVariables {
   static const String ALERT_NO = "CANCEL";
   static const String ALERT_REGISTRATION_SUBMISSION = "Complete Registration?";
   static const String NO_EMAIL_FOUND = "No email address found";
-  static const String NO_EMAIL_FOUND_DESCRIPTION = "Sorry there is no email provided by the API from hm yet.";
+  static const String NO_EMAIL_FOUND_DESCRIPTION =
+      "Sorry there is no email provided by the API from hm yet.";
 
   /* Metrics Strings */
   static const String METRICS_ENABLED = "User Metrics Enabled";
@@ -76,13 +78,17 @@ class StaticVariables {
   static const String CONTACT = "Contact";
   static const String COURSE_DETAILS = "Course Details";
   static const String NO_DESCRIPTION =
-      "Sorry, there is no description available for this course. Please check again later.";
+      "<h4>Sorry, there is no description available for this course. Please check again later.</h4>";
   static const String PROFESSOR = "Professor";
   static const String CAMPUS = "Location";
-  static const String COURSE_CONFLICTS_WITH_OTHER_FAVORIT = "Conflicts with other Favorite";
-  static const String COURSE_CONFLICTS_WITH_FAVORIT = "Conflicts with a Favorite";
-  static const String COURSE_DESCRIPTION_CONFLICTS_WITH_OTHER_FAVORIT = "This course is in conflict with another favorite course:";
-  static const String COURSE_DESCRIPTION_CONFLICTS_WITH_FAVORIT = "This course is unlikely to be chosen together with another favorite course:";
+  static const String COURSE_CONFLICTS_WITH_OTHER_FAVORIT =
+      "Conflicts with other Favorite";
+  static const String COURSE_CONFLICTS_WITH_FAVORIT =
+      "Conflicts with a Favorite";
+  static const String COURSE_DESCRIPTION_CONFLICTS_WITH_OTHER_FAVORIT =
+      "This course is in conflict with another favorite course:";
+  static const String COURSE_DESCRIPTION_CONFLICTS_WITH_FAVORIT =
+      "This course is unlikely to be chosen together with another favorite course:";
 
   static const String MOCK_EMAIL = "example@hm.edu";
 }

--- a/lib/widgets/courseDetails.dart
+++ b/lib/widgets/courseDetails.dart
@@ -6,6 +6,7 @@ import 'package:cie_team1/utils/cieColor.dart';
 import 'package:cie_team1/utils/cieStyle.dart';
 import 'package:cie_team1/utils/staticVariables.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_html_view/flutter_html_view.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class CourseDetails extends StatefulWidget {
@@ -73,7 +74,7 @@ class _CourseDetailsState extends State<CourseDetails> {
         _getSpacing(new EdgeInsets.fromLTRB(5.0, 20.0, 5.0, 30.0)),
         new Container(
           child: new Padding(
-              padding: new EdgeInsets.fromLTRB(10.0, 20.0, 10.0, 30.0),
+              padding: new EdgeInsets.fromLTRB(10.0, 20.0, 10.0, 20.0),
               child: new Text(StaticVariables.DESCRIPTION,
                   style: CiEStyle.getCourseDetailsHeadingStyle())),
         ),
@@ -133,9 +134,8 @@ class _CourseDetailsState extends State<CourseDetails> {
                   ))
               : new Container(),
           buildDescriptionHeadingRow(),
-          new Text(
-            textToShow,
-            style: CiEStyle.getCourseDetailsDescription(),
+          new HtmlView(
+            data: textToShow,
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,11 +6,10 @@ dependencies:
     sdk: flutter
   firebase_analytics: "^1.0.1"
   path_provider: "^0.4.0"
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
   url_launcher: "^3.0.1"
   connectivity: "^0.3.1"
+  flutter_html_view: "^0.3.1"
 
 dev_dependencies:
   flutter_test:
@@ -30,42 +29,10 @@ flutter_icons:
 
 # The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
 
-  # To add assets to your application, add an assets section, like this:
   assets:
     - res/images/hm_logo.png
     - res/images/karlstrasse.png
     - res/images/lothstrasse.png
     - res/images/pasing.png
-
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies, 
-  # see https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
On the course details page, there was the following problem with the course description:
![screenshot_1529956091](https://user-images.githubusercontent.com/15648487/41872876-8cbe5bec-78c3-11e8-8452-25636560ca71.png)




To solve this and show the course description in a nice way. I implemented a HtmlView:
![screenshot_1529956067](https://user-images.githubusercontent.com/15648487/41872881-8f65220e-78c3-11e8-9a9c-d63e543038f6.png)
