### PR TITLE
Store lecturer email from nine

### DIFF
--- a/lib/model/course/course.dart
+++ b/lib/model/course/course.dart
@@ -203,15 +203,13 @@ class Course {
   String name;
   String shortName;
   List<dynamic> actions;
+  String professorEmail;
 
-  //final String name;
   final Set<String> faculties;
   final List<Lecture> lecturesPerWeek;
 
-  //final String description;
   final int hoursPerWeek;
   final int ects;
-  final String professorEmail;
   final String professorName;
   final CourseAvailability available;
   bool isFavourite;

--- a/lib/presenter/courseListPresenter.dart
+++ b/lib/presenter/courseListPresenter.dart
@@ -95,6 +95,23 @@ class CourseListPresenter {
     });
   }
 
+  void updateLecturerInfoFromMemory() {
+    FileStore.readFileAsString(FileStore.LECTURERS).then((String val) {
+      if (val != null) {
+        final List<dynamic> jsonData = json.decode(val)['lecturers'];
+        for (int i = 0; i < jsonData.length; i++) {
+          for (Course c in _courses.getCourses()) {
+            if (c.professorName.contains(jsonData[i]['lastName'])) {
+              if(jsonData[i]['email'] != null && jsonData[i]['email'] != 'null') {
+                c.professorEmail = jsonData[i]['email'];
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
   void syncFavoritedCoursesFromMemory() {
     FileStore.readFileAsString(FileStore.FAVORITES).then((String favoriteIds) {
       if (favoriteIds != null) {

--- a/lib/utils/fileStore.dart
+++ b/lib/utils/fileStore.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 
 class FileStore {
   static const String COURSES = "_courses";
+  static const String LECTURERS = "_lecturers";
   static const String LOGIN = "_login";
   static const String USER_SETTINGS = "_user";
   static const String FAVORITES = "_favorites";

--- a/lib/utils/nineAPIConsumer.dart
+++ b/lib/utils/nineAPIConsumer.dart
@@ -8,9 +8,12 @@ import 'package:http/http.dart';
 
 class NineAPIEngine {
   static const String _NINE_BASE_URL = 'https://nine.wi.hm.edu/api/v2/';
+  static const String _NINE_TRANSITION_URL = 'https://nine.wi.hm.edu/api2/';
   static const String NINE_COURSE_LIST_URL =
       _NINE_BASE_URL + 'courses/FK%2013/CIE/SoSe%2018';
   static const String NINE_AUTH_URL = _NINE_BASE_URL + 'account/login';
+  static const String NINE_LECTURER_URL =
+      _NINE_TRANSITION_URL + 'Lecturer/GetAllLecture';
 
   static Future<Null> pullCourseJSON(
       BuildContext context, bool inBackground) async {
@@ -23,8 +26,10 @@ class NineAPIEngine {
               return GenericIcon.buildGenericSpinner();
             });
       }
-      final response = await get(NINE_COURSE_LIST_URL);
-      FileStore.writeToFile(FileStore.COURSES, response.body);
+      final coursesResponse = await get(NINE_COURSE_LIST_URL);
+      final lecturerResponse = await get(NINE_LECTURER_URL);
+      FileStore.writeToFile(FileStore.COURSES, coursesResponse.body);
+      FileStore.writeToFile(FileStore.LECTURERS, lecturerResponse.body);
       if (!inBackground) {
         Navigator.pop(context);
       }

--- a/lib/views/tabs.dart
+++ b/lib/views/tabs.dart
@@ -35,6 +35,7 @@ class TabsPageState extends State<TabsPage> {
     currentUserPresenter =
         new CurrentUserPresenter(_maybeChangeCallback, Flavor.PROD);
     courseListPresenter.addCoursesFromMemory();
+    courseListPresenter.updateLecturerInfoFromMemory();
     currentUserPresenter.loadUserSettingsFromMemory();
 
     this._appTitle = TabItems[_tab].title;

--- a/lib/widgets/courseList.dart
+++ b/lib/widgets/courseList.dart
@@ -68,18 +68,6 @@ class CourseListState extends State<CourseList> {
     }
   }
 
-  handleUpdate() async {
-    //pullCourseJSON also checks for internet connectivity. This method should
-    //begin execution as soon as possible, check later for setState
-    NineAPIEngine.pullCourseJSON(context, false);
-    var isConnected = await NineAPIEngine.isInternetConnected();
-    if (isConnected == true) {
-      setState(() {
-        courseListPresenter.addCoursesFromMemory();
-      });
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     List<Widget> widgets = new List<Widget>();
@@ -263,6 +251,7 @@ class CourseListState extends State<CourseList> {
   handleRefreshIndicator(BuildContext context, CourseListPresenter presenter) {
     Future<Null> complete = NineAPIEngine.pullCourseJSON(context, true);
     presenter.addCoursesFromMemory();
+    presenter.updateLecturerInfoFromMemory();
     presenter.onChanged(true);
     return complete;
   }


### PR DESCRIPTION
https://github.com/mobileappdevhm/dev-team-1-cie-app-in-flutter/issues/239

Get request from https://nine.wi.hm.edu/api2/Lecturer/GetAllLecture for lecturer data.

If a professor's email is available, store it in our course data.
Currently searches by professors last name as the courseList API does not support "memberId" for lecturers.

Made the professorEmail String not final so our course object could be modified later if we discover later (in this second get request) that an email exists. 

Even though its not clean, I think it's better than adding to the already long addCoursesFromMemory method (and if we made this longer, either of the two get requests failing could mean that we don't update any data).